### PR TITLE
Improve argument passing and errs

### DIFF
--- a/HtmlTidy.sublime-settings
+++ b/HtmlTidy.sublime-settings
@@ -2,7 +2,7 @@
   // This option specifies the right margin Tidy uses for line wrapping. 
   // Tidy tries to wrap lines so that they do not exceed this length. 
   // Set wrap to zero if you want to disable line wrapping.
-  "wrap": "0",
+  "wrap": 0,
 
   // Suppress the welcome and informational messages.
   "quiet": true,
@@ -23,11 +23,13 @@
   // This option specifies if Tidy should begin each attribute on a new line.
   "indent-attributes": false,
 
-  // This option specifies if Tidy should indent block-level tags
-  "indent": "auto",
+  // This option specifies how Tidy should indent tags.
+  // possible values: true, auto, false
+  // "auto" doesn't seem to work with PHP Tidy library
+  "indent": true,
 
   //This option specifies the number of spaces Tidy uses to indent content
-  "indent-spaces": "2",
+  "indent-spaces": 4,
 
   // This option specifies if Tidy should line wrap attribute values, for easier editing. 
   "wrap-attributes": false,

--- a/html_tidy.py
+++ b/html_tidy.py
@@ -103,12 +103,7 @@ scriptpath = os.path.join(pluginpath, 'tidy.php')
 ############### FUNCTIONS ###############
 
 
-def tidy_string(input_string, script, args):
-    'Adapted from the Sublime Text 1 webdevelopment package.'
-    #print 'HtmlTidy: '
-    #print args
-    command = [script] + args
-
+def tidy_string(input_string, command):
     p = subprocess.Popen(
         command,
         bufsize=-1,
@@ -154,15 +149,14 @@ def find_tidier():
             tidypath = os.path.normpath(pluginpath + '/win/tidy.exe')
             subprocess.call([tidypath, "-v"])
             print "HTMLTidy: using Tidy found here: " + tidypath
-            return tidypath
+            return tidypath, 'list'
         except OSError:
             print "HTMLTidy: Didn't find tidy.exe in " + pluginpath
             pass
-
     try:
         subprocess.call(['php', '-v'])
         print "HTMLTidy: Using PHP Tidy module."
-        return 'php "' + os.path.normpath(scriptpath) + '"'
+        return 'php "' + os.path.normpath(scriptpath) + '"', 'string'
     except OSError:
         print "HTMLTidy: Not using PHP"
         pass
@@ -170,7 +164,7 @@ def find_tidier():
     try:
         subprocess.call(['tidy', '-v'])
         print "HTMLTidy: using Tidy found in PATH"
-        return "tidy"
+        return "tidy", 'string'
     except OSError:
         print "HTMLTidy: Didn't find Tidy in the PATH."
         pass
@@ -181,6 +175,17 @@ def find_tidier():
 def fixup(string):
     'Remove double newlines & decode text.'
     return re.sub(r'\r\n|\r', '\n', string.decode('utf-8'))
+
+
+def compile_args(args, script, style):
+    'Take a list of tuples and present it as either a list of a string in --opt=arg style'
+    if style == 'string':
+        return script + ' ' + ' '.join(['--' + a[0] + '=' + a[1] for a in args])
+    if style == 'list':
+        output = []
+        for a in args:
+            output.extend(a)
+        return [script] + output
 
 
 def get_args(args):
@@ -198,12 +203,12 @@ def get_args(args):
             continue
 
         if custom_value == True:
-            custom_value = '1'
+            custom_value = 1
         if custom_value == False:
-            custom_value = '0'
+            custom_value = 0
 
         # print "HtmlTidy: setting " + option + ": " + custom_value
-        args.extend(["--" + option, str(custom_value)])
+        args += [(option, str(custom_value))]
 
     return args
 
@@ -237,14 +242,14 @@ class HtmlTidyCommand(sublime_plugin.TextCommand):
         print('HtmlTidy: invoked on file: %s' % (self.view.file_name()))
 
         try:
-            script = find_tidier()
+            script, arg_type = find_tidier()
         except OSError:
             print "HTMLTidy: Couldn't find Tidy or PHP. Stopping without Tidying anything."
             return
 
         tab_size = int(self.view.settings().get('tab_size', 4))
         #print('HtmlTidy: tab_size: %s' % (tab_size))
-        args = ['--tab-size', str(tab_size)]
+        args = [('indent-spaces', str(tab_size))]
 
         # Get arguments from config files.
         # This extends the argument just given, so that a user-given value for tab_size takes precedence.
@@ -255,16 +260,18 @@ class HtmlTidyCommand(sublime_plugin.TextCommand):
         # Get current selection(s).
         if not self.view.sel()[0].empty():
             # If selection, then make sure not to add body tags and the like.
-            args.extend(["--show-body-only", '1'])
+            args += [('show-body-only', '1')]
 
         else:
             # If no selection, get the entire view.
             self.view.sel().add(sublime.Region(0, self.view.size()))
 
+        command = compile_args(args, script, style=arg_type)
+        print 'HtmlTidy: ' + str(command)
         #print "HtmlTidy: Passing this script and arguments: " + script + " " + str(args)
         for sel in self.view.sel():
 
-            tidied, err, retval = tidy_string(self.view.substr(sel), script, args)
+            tidied, err, retval = tidy_string(self.view.substr(sel), command)
 
             err = fixup(err)
 
@@ -288,6 +295,5 @@ class HtmlTidyCommand(sublime_plugin.TextCommand):
                 nv = self.view.window().new_file()
                 nv.set_scratch(1)
                 # Append the given command to the error message.
-                command = script + " " + " ".join(x for x in args)
-                nv.insert(edit, 0, err + "\n" + command)
+                nv.insert(edit, 0, err + "\n" + str(command))
                 nv.set_name('HTMLTidy: Tidy errors')

--- a/html_tidy.py
+++ b/html_tidy.py
@@ -180,7 +180,7 @@ def fixup(string):
 def compile_args(args, script, style):
     'Take a list of tuples and present it as either a list of a string in --opt=arg style'
     if style == 'string':
-        return script + ' ' + ' '.join(['--' + a[0] + '=' + a[1] for a in args])
+        return script + ' ' + ' '.join([a[0] + '=' + a[1] for a in args])
     if style == 'list':
         output = []
         for a in args:
@@ -208,7 +208,7 @@ def get_args(args):
             custom_value = 0
 
         # print "HtmlTidy: setting " + option + ": " + custom_value
-        args += [(option, str(custom_value))]
+        args += [('--' + option, str(custom_value))]
 
     return args
 
@@ -249,7 +249,7 @@ class HtmlTidyCommand(sublime_plugin.TextCommand):
 
         tab_size = int(self.view.settings().get('tab_size', 4))
         #print('HtmlTidy: tab_size: %s' % (tab_size))
-        args = [('indent-spaces', str(tab_size))]
+        args = [('--indent-spaces', str(tab_size))]
 
         # Get arguments from config files.
         # This extends the argument just given, so that a user-given value for tab_size takes precedence.
@@ -260,7 +260,7 @@ class HtmlTidyCommand(sublime_plugin.TextCommand):
         # Get current selection(s).
         if not self.view.sel()[0].empty():
             # If selection, then make sure not to add body tags and the like.
-            args += [('show-body-only', '1')]
+            args += [('--show-body-only', '1')]
 
         else:
             # If no selection, get the entire view.

--- a/tidy.php
+++ b/tidy.php
@@ -16,18 +16,18 @@ error_reporting( E_ALL );
 // and tidy.sourceforge.net/docs/tidy_man.html
 // '::' marks all as optional
 
-$short_options = 'o::' +
-    'f::' +
-    'm::' +
-    'i::' +
-    'w::' +
-    'u::' +
-    'c::' +
-    'b::' +
-    'n::' +
-    'e::' +
-    'q::' +
-    'v::' +
+$short_options = 'o::' .
+    'f::' .
+    'm::' .
+    'i::' .
+    'w::' .
+    'u::' .
+    'c::' .
+    'b::' .
+    'n::' .
+    'e::' .
+    'q::' .
+    'v::' .
     'h::' ;
 
 $long_options = array(
@@ -126,8 +126,14 @@ $arguments = getopt( $short_options, $long_options );
 
 $input = stream_get_contents(STDIN);
 
-$tidy = new Tidy();
-$tidy->parseString( $input, $arguments, 'utf8' );
+try {
+    $tidy = new Tidy();
+    $tidy->parseString( $input, $arguments, 'utf8' );
+
+} catch (Exception $e) {
+    fwrite( STDERR, "Error: PHP doesn't have libtidy installed.\n" );
+    exit( 1 );
+}
 
 fwrite( STDOUT, (string)$tidy );
 


### PR DESCRIPTION
Plugin now passes arguments as either a list or a string, depending on the type of tidy being used.

bundled tidy.exe: recieves list of arguments. (This is first choice on Windows, only windows)
tidy PHP library and tidy in PATH: recieve string of arguments. 
(OS X has an old tidy in its path, PHP is preferred)

If you'd prefer to try the exe on all platforms (including linux), remove the 'if' statement on tidy_html.py, line 147.

This is tested on OS X and a no-PHP Windows environment and is working fine.

The PHP library appears has trouble with the indent=auto setting. I looked at the source, and the option appears to be set as a Bool, so "auto" is ignored. A work-around for PHP is to set indent-attributes=1
