### PR TITLE
Fix UnboundLocalError when tidy selected HTML content

### DIFF
--- a/html_tidy.py
+++ b/html_tidy.py
@@ -307,6 +307,7 @@ class HtmlTidyCommand(sublime_plugin.TextCommand):
         # Get current selection(s).
         if not self.view.sel()[0].empty():
             # If selection, then make sure not to add body tags and the like.
+            deselect_flag = False
             args += [('--show-body-only', '1')]
 
         else:


### PR DESCRIPTION
If I select some HTML content and run tidy command, I will get the following error.
Traceback (most recent call last):
  File ".\sublime_plugin.py", line 362, in run_
  File ".\html_tidy.py", line 339, in run
UnboundLocalError: local variable 'deselect_flag' referenced before assignment
